### PR TITLE
systemd timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Put these files in `/etc/systemd/system/`:
 
 Now simply enable the timer with:
 ```bash
+$ systemctl start restic-backup.timer
 $ systemctl enable restic-backup.timer
 ````
 


### PR DESCRIPTION
systemd timers need to be started as well as enabled, otherwise the timer won't actually be registered via `systemctl is-active restic-backup.timer`.