### PR TITLE
Change README to point to the HTTPS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Note, you can use any of the supported [storage backends](https://restic.readthe
 Tip: The steps in this section will instruct you to copy files from this repo to system directories. If you don't want to do this manually, you can use the Makefile:
 
 ```bash
-$ git clone git@github.com:erikw/restic-systemd-automatic-backup.git
+$ git clone https://github.com/erikw/restic-systemd-automatic-backup.git
 $ cd restic-systemd-automatic-backup
 $ sudo make install
 ````


### PR DESCRIPTION
Most people probably want to clone from the repo over HTTPS, not git+ssh.
The latter usually requiring permissions:
> fatal: Could not read from remote repository.
> Please make sure you have the correct access rights