### PR TITLE
Set permissions for systemd units to 644

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ install-conf: | etc/restic/b2_env.sh etc/restic/b2_pw.txt
 # target: install-systemd - Install systemd timer and service files
 install-systemd:
 	install -d $(DEST_SYSTEMD)
-	install $(SRCS_SYSTEMD) $(DEST_SYSTEMD)
+	install -m 0644 $(SRCS_SYSTEMD) $(DEST_SYSTEMD)


### PR DESCRIPTION
Systemd Units should not be executable:
```
Jul 13 23:52:41 systemd[1]: Configuration file /usr/lib/systemd/system/restic-check.service is marked executable. Please remove executable permission bits. Proceeding anyway.
Jul 13 23:52:41 systemd[1]: Configuration file /usr/lib/systemd/system/restic-check.timer is marked executable. Please remove executable permission bits. Proceeding anyway.
```
On Arch they are 0755 so we need to force 0644. This is a bit of a reversion of #15 where we assumed it would be in /etc/ and the default would be acceptable. 