### PR TITLE
Forget now has --prune which might be more efficent.

### DIFF
--- a/usr/local/sbin/restic_backup.sh
+++ b/usr/local/sbin/restic_backup.sh
@@ -71,7 +71,8 @@ wait $!
 restic forget \
 	--verbose \
 	--tag $BACKUP_TAG \
-        --prune
+	--option b2.connections=$B2_CONNECTIONS \
+        --prune \
 	--group-by "paths,tags" \
 	--keep-daily $RETENTION_DAYS \
 	--keep-weekly $RETENTION_WEEKS \

--- a/usr/local/sbin/restic_backup.sh
+++ b/usr/local/sbin/restic_backup.sh
@@ -71,18 +71,12 @@ wait $!
 restic forget \
 	--verbose \
 	--tag $BACKUP_TAG \
+        --prune
 	--group-by "paths,tags" \
 	--keep-daily $RETENTION_DAYS \
 	--keep-weekly $RETENTION_WEEKS \
 	--keep-monthly $RETENTION_MONTHS \
 	--keep-yearly $RETENTION_YEARS &
-wait $!
-
-# Remove old data not linked anymore.
-# See restic-prune(1) or http://restic.readthedocs.io/en/latest/060_forget.html
-restic prune \
-	--option b2.connections=$B2_CONNECTIONS \
-	--verbose &
 wait $!
 
 # Check repository for errors.

--- a/usr/local/sbin/restic_backup.sh
+++ b/usr/local/sbin/restic_backup.sh
@@ -65,7 +65,7 @@ restic backup \
 	$BACKUP_PATHS &
 wait $!
 
-# Dereference old backups.
+# Dereference and delete/prune old backups.
 # See restic-forget(1) or http://restic.readthedocs.io/en/latest/060_forget.html
 # --group-by only the tag and path, and not by hostname. This is because I create a B2 Bucket per host, and if this hostname accidentially change some time, there would now be multiple backup sets.
 restic forget \


### PR DESCRIPTION
I was comparing one of my servers and it uses restic forget --prune instead of restic prune. It appears a bit more efficient as it [only runs prune if there is something to prune. ](https://restic.readthedocs.io/en/stable/060_forget.html?highlight=--prune)