### PR TITLE
README: Fix backup_exclude destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ restic init
 Put this file in `/usr/local/sbin`:
 * `restic_backup.sh`: A script that defines how to run the backup. Edit this file to respect your needs in terms of backup which paths to backup, retention (number of backups to save), etc.
 
-Put this file in `/`:
+Copy this file to `/etc/restic/backup_exclude` or `~/.backup_exclude`:
 * `.backup_exclude`: A list of file pattern paths to exclude from you backups, files that just occupy storage space, backup-time, network and money.
 
 


### PR DESCRIPTION
restic_backup.sh doesn't actually look for `/.backup_exclude` it seems