### PR TITLE
Fix conflicts for restic-check service

### DIFF
--- a/etc/systemd/system/restic-check.service
+++ b/etc/systemd/system/restic-check.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Check restic backup Backblaze B2 for errors
 OnFailure=status-email-user@%n.service
-Conflicts=restic.service
+Conflicts=restic-backup.service
 Requires=nm-unmetered-connection.service
 
 [Service]


### PR DESCRIPTION
This fixes a typo in the restic-check.service file that makes sure a backup is not running before starting a check.