### PR TITLE
Fix installation of template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+# Prevent check-in of these sensitive files. Instead they are generated from the corresponding *.template file.
 /etc/restic/b2_pw.txt
 /etc/restic/b2_env.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- $(make install) now works for the *.template files (#40)
 
 ## [1.0.0] - 2021-12-02
 It's time to call this a proper major version!

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 ### Macros ###
 SRCS_SCRIPTS	= $(filter-out %cron_mail, $(wildcard usr/local/sbin/*))
-SRCS_CONF	= $(filter-out %template, $(wildcard etc/restic/*))
+SRCS_CONF	= $(patsubst %.template, %, $(wildcard etc/restic/*))
 SRCS_SYSTEMD	= $(wildcard etc/systemd/system/*)
 
 # Just set PREFIX in envionment, like
@@ -32,15 +32,15 @@ install-scripts:
 	install -d $(DEST_SCRIPTS)
 	install -m 0744 $(SRCS_SCRIPTS) $(DEST_SCRIPTS)
 
-etc/restic/b2_env.sh:
-	install -m 0600 etc/restic/b2_env.sh.template /etc/restic/b2_env.sh
-
-etc/restic/b2_pw.txt:
-	install -m 0600 etc/restic/b2_pw.txt.template /etc/restic/b2_pw.txt
+# Copy templates to new files with restricted permissions.
+# Why? Because the non-template files are git-ignored to preovent that someone who clones or forks this repo checks in their sensitive data like the B2 password!
+etc/restic/b2_env.sh etc/restic/b2_pw.txt:
+	install -m 0600 $@.template $@
 
 # target: install-conf - Install restic configuration files.
 # will create these files locally only if they don't already exist
-install-conf: | etc/restic/b2_env.sh etc/restic/b2_pw.txt
+# | means that dependencies are order-ony i.e. only created if they don't already exist.
+install-conf: | $(SRCS_CONF)
 	install -d $(DEST_CONF)
 	install -m 0600 $(SRCS_CONF) $(DEST_CONF)
 


### PR DESCRIPTION
The target that copies the *.template files (#15) had a '/' prefixed which
should not be there. The copy should be locally here. The real install
happens in the install-conf that respects $PREFIX

Fixes #40
