### PR TITLE
Fix make install failing when run multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 ### Macros ###
 SRCS_SCRIPTS	= $(filter-out %cron_mail, $(wildcard usr/local/sbin/*))
-SRCS_CONF	= $(patsubst %.template, %, $(wildcard etc/restic/*))
+# $(sort) remove duplicates that comes from running make install >1 times.
+SRCS_CONF	= $(sort $(patsubst %.template, %, $(wildcard etc/restic/*)))
 SRCS_SYSTEMD	= $(wildcard etc/systemd/system/*)
 
 # Just set PREFIX in environment, like


### PR DESCRIPTION
Due to the security feature preventing checking in B2 credentials to
git, the install target would get the same file twice due to pattern
subsitution.

This issue is not visible with BSD install as it ignores the issue, but
GNU install wil fail.

Fixes #46